### PR TITLE
Fix typein newline and tab support

### DIFF
--- a/pkg/humantype/humantype.go
+++ b/pkg/humantype/humantype.go
@@ -12,6 +12,8 @@ import (
 	_ "github.com/go-vgo/robotgo/mouse"
 )
 
+var keyTap = robotgo.KeyTap
+
 // NearbyKeys maps characters to their neighboring keys on a QWERTY keyboard.
 var NearbyKeys = map[rune][]rune{
 	'q': {'w', 'a', 's'}, 'w': {'q', 'e', 's', 'd', 'a'}, 'e': {'w', 'r', 'd', 'f', 's'}, 'r': {'e', 't', 'f', 'g', 'd'},
@@ -71,21 +73,30 @@ func Type(text string, cfg Config) {
 		if rand.Intn(100) < cfg.TypoChance {
 			if near, ok := NearbyKeys[unicode.ToLower(char)]; ok && len(near) > 0 {
 				wrongChar := near[rand.Intn(len(near))]
-				robotgo.KeyTap(string(wrongChar))
+				keyTap(string(wrongChar))
 				time.Sleep(time.Duration(rand.Intn(40)+60) * time.Millisecond)
-				robotgo.KeyTap("backspace")
+				keyTap("backspace")
 				time.Sleep(time.Duration(rand.Intn(20)+40) * time.Millisecond)
 			}
 		}
 
-		robotgo.KeyTap(string(char))
+		key := string(char)
+		switch char {
+		case '\n':
+			key = "enter"
+		case '\t':
+			key = "tab"
+		case '\r':
+			continue
+		}
+		keyTap(key)
 
 		// Rare double-tap typo - type, delete, retype
-		if rand.Intn(200) < cfg.DoubleTypoChance && char != ' ' && char != '\n' {
+		if rand.Intn(200) < cfg.DoubleTypoChance && char != ' ' && char != '\n' && char != '\r' {
 			time.Sleep(time.Duration(rand.Intn(80)+70) * time.Millisecond)
-			robotgo.KeyTap("backspace")
+			keyTap("backspace")
 			time.Sleep(time.Duration(rand.Intn(40)+50) * time.Millisecond)
-			robotgo.KeyTap(string(char))
+			keyTap(key)
 		}
 
 		// Calculate delay

--- a/pkg/humantype/humantype_test.go
+++ b/pkg/humantype/humantype_test.go
@@ -1,0 +1,74 @@
+package humantype
+
+import (
+	"testing"
+)
+
+func TestType(t *testing.T) {
+	var tappedKeys []string
+
+	// Mock keyTap
+	oldKeyTap := keyTap
+	defer func() { keyTap = oldKeyTap }()
+
+	keyTap = func(key string, args ...interface{}) error {
+		tappedKeys = append(tappedKeys, key)
+		return nil
+	}
+
+	cfg := DefaultConfig()
+	cfg.TypoChance = 0        // Disable typos for predictable testing
+	cfg.DoubleTypoChance = 0  // Disable double-tap typos
+	cfg.PauseChance = 0       // Disable end pause
+
+	// Use very small delays to speed up tests
+	cfg.BaseDelay = 1
+	cfg.DelayVariance = 1
+	cfg.NewlineBaseDelay = 1
+	cfg.NewlineExtraDelay = 1
+	cfg.SpaceExtraDelay = 1
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "basic text",
+			input:    "abc",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "with newline",
+			input:    "a\nb",
+			expected: []string{"a", "enter", "b"},
+		},
+		{
+			name:     "with tab",
+			input:    "a\tb",
+			expected: []string{"a", "tab", "b"},
+		},
+		{
+			name:     "with carriage return",
+			input:    "a\r\nb",
+			expected: []string{"a", "enter", "b"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tappedKeys = nil
+			Type(tc.input, cfg)
+
+			if len(tappedKeys) != len(tc.expected) {
+				t.Fatalf("expected %d keys, got %d: %v", len(tc.expected), len(tappedKeys), tappedKeys)
+			}
+
+			for i := range tc.expected {
+				if tappedKeys[i] != tc.expected[i] {
+					t.Errorf("at index %d: expected %q, got %q", i, tc.expected[i], tappedKeys[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `typein` tool was ignoring newlines because `robotgo.KeyTap("\n")` does not correctly simulate an Enter key press. I've updated the `humantype` package to map `\n` to `"enter"` and `\t` to `"tab"`. I also added handling for `\r` to avoid issues with CRLF line endings. The code was refactored to allow mocking of the keyboard simulation for unit testing, and a new test file was added to verify these changes.

---
*PR created automatically by Jules for task [360710798370455521](https://jules.google.com/task/360710798370455521) started by @JasonLovesDoggo*